### PR TITLE
Add API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Point your browser to [http://localhost:8000](http://localhost:8000) to view the
 
 ## PHP and JavaScript
 
-The frontend uses Vue.js with Axios to fetch dating profiles from an external API (`20fhbe2020.be`). The PHP files mainly generate the HTML structure (header, navigation and footer) and provide dynamic meta tags.
+The frontend uses Vue.js with Axios to fetch dating profiles from a remote API. The API base URL can be configured via the `BASE_API_URL` environment variable and defaults to `https://20fhbe2020.be`. Endpoints are defined in `includes/config.php` and included where needed so the strings aren't duplicated. The PHP files mainly generate the HTML structure (header, navigation and footer) and provide dynamic meta tags.
 
 ## License and attribution
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,10 @@
+<?php
+$baseApiUrl = getenv('BASE_API_URL') ?: 'https://20fhbe2020.be';
+
+return [
+    'BASE_API_URL' => $baseApiUrl,
+    'BANNER_ENDPOINT' => $baseApiUrl . '/profile/banner9/120',
+    'PROFILE_ENDPOINT' => $baseApiUrl . '/profile/get0/9/',
+    'PROVINCE_ENDPOINT' => $baseApiUrl . '/profile/province/be',
+];
+

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,6 +1,7 @@
 <?php
   $companyName = "Zoekertjes België";
   include('includes/nav_items.php');
+  $config = include(__DIR__ . '/config.php');
 
   ini_set('display_errors', 1);
   ini_set('display_startup_errors', 1);
@@ -17,10 +18,10 @@
     <meta http-equiv="Content-Security-Policy" content="
     default-src *; 
     font-src 'self' https://fonts.gstatic.com;
-    img-src 'self' https://16hl07csd16.nl/ https://region1.google-analytics.com www.googletagmanager.com https://ssl.gstatic.com https://www.gstatic.com https://www.google-analytics.com https://20fhbe2020.be/;
+    img-src 'self' https://16hl07csd16.nl/ https://region1.google-analytics.com www.googletagmanager.com https://ssl.gstatic.com https://www.gstatic.com https://www.google-analytics.com <?php echo $config['BASE_API_URL']; ?>/;
     style-src 'self' https://tagmanager.google.com https://fonts.googleapis.com/ 'unsafe-inline'; 
     style-src-elem 'self' https://tagmanager.google.com https://fonts.googleapis.com/ 'unsafe-inline'; 
-    connect-src 'self' https://region1.google-analytics.com https://tagmanager.google.com/ https://www.google-analytics.com https://16hl07csd16.nl/ https://20fhbe2020.be/;
+    connect-src 'self' https://region1.google-analytics.com https://tagmanager.google.com/ https://www.google-analytics.com https://16hl07csd16.nl/ <?php echo $config['BASE_API_URL']; ?>/;
     script-src 'self' http://* https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/ https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/ 'nonce-googletagmanager' 'nonce-2726c7f26c' 'sha256-WwSlXI54tpz3oRisOne8KKEqXFjbTYCI2AzKef7+7nE=' 'unsafe-inline' 'unsafe-eval'
     ">
     <link rel="apple-touch-icon" sizes="57x57" href="img/fav/apple-icon-57x57.png">

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
 
     include("includes/array_prov.php");
     include("includes/array_tips.php");
-  	include("includes/header.php");
+    include("includes/header.php");
 ?>
 <div class="container">
     <!-- Jumbotron Header -->
@@ -43,7 +43,7 @@
         </div>
     </div>
     <script nonce="2726c7f26c">
-        var api_url= "https://20fhbe2020.be/profile/banner9/120";
+        var api_url= "<?php echo $config['BANNER_ENDPOINT']; ?>";
     </script>
     <!-- Pagination -->
     <nav class="nav-pag" aria-label="Page navigation">

--- a/profile.php
+++ b/profile.php
@@ -1,5 +1,5 @@
 <?php
-	include('includes/header.php');
+        include('includes/header.php');
 ?>
 <!-- Page Content -->
 <div class="container" id="profiel" v-cloak>
@@ -29,8 +29,8 @@
     <div id="footer-banner"></div>
 </div><!-- Container -->
 
-<script nonce="2726c7f26c">    
-    var api_url= "https://20fhbe2020.be/profile/get0/9/";
+<script nonce="2726c7f26c">
+    var api_url= "<?php echo $config['PROFILE_ENDPOINT']; ?>";
     var ref_id= "32"; //de ref_id vd landingwebsite
 </script>
 <?php 

--- a/provincie.php
+++ b/provincie.php
@@ -1,7 +1,7 @@
-<?php 
+<?php
 
   include('includes/array_prov.php');
-	include('includes/header.php');
+        include('includes/header.php');
 
 	function strip_bad_chars( $input ) {
 		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
@@ -43,7 +43,7 @@
         </div>
       </div>
       <script nonce="2726c7f26c">
-        var api_url= "https://20fhbe2020.be/profile/province/be/<?=$zoek['name']?>/120";
+        var api_url= "<?php echo $config['PROVINCE_ENDPOINT'] . '/' . $zoek['name'] . '/120'; ?>";
       </script>
 
       <!-- Pagination -->


### PR DESCRIPTION
## Summary
- add `includes/config.php` and centralize API endpoints
- reference the config in templates and content security policy
- document `BASE_API_URL` in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68492cb3635883248caed09b6b0d015e