### PR TITLE
Implement configurable debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Point your browser to [http://localhost:8000](http://localhost:8000) to view the
 
 The frontend uses Vue.js with Axios to fetch dating profiles from a remote API. The API base URL can be configured via the `BASE_API_URL` environment variable and defaults to `https://20fhbe2020.be`. Endpoints are defined in `includes/config.php` and included where needed so the strings aren't duplicated. The PHP files mainly generate the HTML structure (header, navigation and footer) and provide dynamic meta tags.
 
+PHP error display is disabled by default. Set the `APP_DEBUG` environment variable to `true` when developing to enable verbose error output.
+
 ## License and attribution
 
 This project is released under the MIT License. The layout originates from the [Start Bootstrap Heroic Features](https://github.com/BlackrockDigital/startbootstrap-heroic-features) template.

--- a/includes/config.php
+++ b/includes/config.php
@@ -3,6 +3,8 @@ $baseApiUrl = getenv('BASE_API_URL') ?: 'https://20fhbe2020.be';
 
 return [
     'BASE_API_URL' => $baseApiUrl,
+    // When APP_DEBUG is set to 'true', development error reporting is enabled
+    'DEBUG' => getenv('APP_DEBUG') === 'true',
     'BANNER_ENDPOINT' => $baseApiUrl . '/profile/banner9/120',
     'PROFILE_ENDPOINT' => $baseApiUrl . '/profile/get0/9/',
     'PROVINCE_ENDPOINT' => $baseApiUrl . '/profile/province/be',

--- a/includes/header.php
+++ b/includes/header.php
@@ -3,9 +3,12 @@
   include('includes/nav_items.php');
   $config = include(__DIR__ . '/config.php');
 
-  ini_set('display_errors', 1);
-  ini_set('display_startup_errors', 1);
-  error_reporting(E_ALL);
+  // Enable verbose error reporting only when APP_DEBUG=true
+  if (!empty($config['DEBUG'])) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+  }
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- add `DEBUG` flag in `includes/config.php` controlled by `APP_DEBUG` environment variable
- use the flag in `includes/header.php` so error display is off by default
- document new `APP_DEBUG` variable in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684930aa4e408324be9f5b0728bc4112