### PR TITLE
Fix cookie banner CSP inline script issue

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -21,7 +21,7 @@
       <label><input type="checkbox" id="cookie-statistics"> Statistics (e.g. Google Analytics)</label><br>
       <label><input type="checkbox" id="cookie-marketing"> Marketing (e.g. Google Ads, Meta Pixel)</label><br><br>
       <button type="submit" style="background-color: #007BFF; color: white; border: none; padding: 10px 15px; margin-right: 10px; cursor: pointer;">Save preferences</button>
-      <button type="button" onclick="acceptAllCookies()" style="background-color: #28a745; color: white; border: none; padding: 10px 15px; cursor: pointer;">Accept all</button>
+      <button type="button" id="accept-all-cookies" style="background-color: #28a745; color: white; border: none; padding: 10px 15px; cursor: pointer;">Accept all</button>
     </form>
   </div>
 </div>

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -65,6 +65,8 @@ document.getElementById('cookie-form').addEventListener('submit', function(e) {
   if (marketing) loadMarketing();
 });
 
+document.getElementById('accept-all-cookies').addEventListener('click', acceptAllCookies);
+
 function acceptAllCookies() {
   document.getElementById('cookie-statistics').checked = true;
   document.getElementById('cookie-marketing').checked = true;


### PR DESCRIPTION
## Summary
- remove inline `onclick` from cookie consent button
- bind cookie accept logic using JavaScript event listener

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68493fe7e2488324a614996cb9596cc8