### PR TITLE
Fix index error reporting

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,11 @@
 <?php
-    error_reporting(-1);
-		ini_set('display_errors', 1);
-	define("TITLE", "De beste datingsite van België");
+    $config = include('includes/config.php');
+    if (!empty($config['DEBUG'])) {
+        ini_set('display_errors', 1);
+        ini_set('display_startup_errors', 1);
+        error_reporting(E_ALL);
+    }
+        define("TITLE", "De beste datingsite van België");
 
     include("includes/array_prov.php");
     include("includes/array_tips.php");


### PR DESCRIPTION
## Summary
- set up index.php to load config first
- enable verbose PHP errors when DEBUG is on
- drop hardcoded `error_reporting` calls

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494d8f408c8324be45f77df14bf713