### PR TITLE
Improve canonical URL handling

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -67,6 +67,15 @@
             $canonicalUrl = $baseUrl . "/datingtips-" . htmlspecialchars($_GET['tip']);
             $title = "Datingtips " . htmlspecialchars($_GET['tip']);
         }
+
+        // When no query parameters are present, build canonical from script name
+        if (empty($_GET)) {
+            $script = basename($_SERVER['SCRIPT_NAME']);
+            if ($script !== 'index.php') {
+                $canonicalUrl = $baseUrl . '/' . $script;
+            }
+        }
+
         echo '<link rel="canonical" href="' . $canonicalUrl . '" >';
         echo '<title>' . $title . '</title>';
     ?>


### PR DESCRIPTION
## Summary
- build canonical from script name when no query parameters

## Testing
- `php -l includes/header.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514434fabc8324bd1b7de01d583313