### PR TITLE
Update title suffix logic

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -76,6 +76,11 @@
             }
         }
 
+        // Always append site name to the title when not already present
+        if (strpos($title, 'Zoekertjes België') === false) {
+            $title .= ' - Zoekertjes België';
+        }
+
         echo '<link rel="canonical" href="' . $canonicalUrl . '" >';
         echo '<title>' . $title . '</title>';
     ?>


### PR DESCRIPTION
## Summary
- keep canonical URL logic intact
- add logic to append the site name to the computed title

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852ac6a541083249b78b5cfd9eee0ab