### PR TITLE
Fix navigation URLs to use base URL

### DIFF
--- a/404.php
+++ b/404.php
@@ -9,7 +9,7 @@
        		<h1>Oeps!</h1>
        		<h2>Helaas is de opgevraagde pagina niet gevonden.</h2>
           	<p>	Redenen hiervoor kunnen zijn:<br />1. Het profiel dat je probeert te benaderen bestaat niet meer.<br />2. Het webadres is niet correct ingevoerd.<br /><br />Gebruik het menu op deze pagina om een nieuwe keuze te maken.</p>
-        	<a href="index.php" class="btn btn-primary"> Startpagina </a>
+                <a href="<?php echo $baseUrl; ?>/" class="btn btn-primary"> Startpagina </a>
 		  	<?php
 		    	foreach ($navItems as $item) {
 		        echo "<a class=\"btn btn-primary\" href=\"$item[slug]\" style=\"margin: 1px;\">$item[title]</a>";

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -3,14 +3,18 @@
         <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle drpdwn" href="#" id="navbarDropdownProvinces" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Daten in België</a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdownProvinces">
-                        <?php foreach ($navItems as $item) {echo "<a class=\"dropdown-item\" href=\"$item[slug]\">$item[title]</a>";} ?>
+                        <?php foreach ($navItems as $item) {
+                            echo "<a class=\"dropdown-item\" href=\"{$baseUrl}/{$item['slug']}\">{$item['title']}</a>";
+                        } ?>
                 </div>
         </li>
     <!-- Datingtips links -->
         <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle drpdwn" href="#" id="navbarDropdownTips" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Datingtips</a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdownTips">
-                    <?php foreach ($navItems2 as $item2) {echo "<a class=\"dropdown-item\" href=\"$item2[slug]\">$item2[title]</a>";} ?>
+                    <?php foreach ($navItems2 as $item2) {
+                        echo "<a class=\"dropdown-item\" href=\"{$baseUrl}/{$item2['slug']}\">{$item2['title']}</a>";
+                    } ?>
                 </div>
         </li>
     <!-- Nieuwe sociale media links -->

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in België'" @error="imgError"></a>
+                <a :href="'<?php echo $baseUrl; ?>/daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in België'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  
@@ -43,7 +43,7 @@
                         <li class="list-group-item">Provincie: {{ profile.province }}</li>
                     </ul>
                 </div>
-                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+                <a :href="'<?php echo $baseUrl; ?>/daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
             </div>
         </div>
         <script>

--- a/provincie.php
+++ b/provincie.php
@@ -16,7 +16,7 @@
   <div class="row" v-cloak>
     <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
       <div class="card h-100">
-        <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Daten in ' + profile.province + ' met ' + profile.name" :title="'Bekijk het profiel van ' + profile.name + ' uit ' + profile.city" @error="imgError"></a>
+        <a :href="'<?php echo $baseUrl; ?>/daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Daten in ' + profile.province + ' met ' + profile.name" :title="'Bekijk het profiel van ' + profile.name + ' uit ' + profile.city" @error="imgError"></a>
         <div class="card-body">
           <div class="card-top">
             <h4 class="card-title">{{ profile.name }}</h4>  
@@ -28,7 +28,7 @@
             <li class="list-group-item">Provincie: {{ profile.province }}</li>
           </ul>
         </div>
-        <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
+        <a :href="'<?php echo $baseUrl; ?>/daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
       </div>
     </div>
   </div><!-- /.row -->


### PR DESCRIPTION
## Summary
- use `$baseUrl` for nav dropdown links
- prefix profile links with `$baseUrl`
- update 404 link to use `$baseUrl`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852acfcc9288324a5ec4cfdf701f9e5