### PR TITLE
Fix undefined nav arrays on 404 page

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,17 +10,12 @@ $base = __DIR__;
        		<h1>Oeps!</h1>
        		<h2>Helaas is de opgevraagde pagina niet gevonden.</h2>
           	<p>	Redenen hiervoor kunnen zijn:<br />1. Het profiel dat je probeert te benaderen bestaat niet meer.<br />2. Het webadres is niet correct ingevoerd.<br /><br />Gebruik het menu op deze pagina om een nieuwe keuze te maken.</p>
-        	<a href="index.php" class="btn btn-primary"> Startpagina </a>
-		  	<?php
-                        foreach ($navItemsNL as $item) {
+                <a href="index.php" class="btn btn-primary"> Startpagina </a>
+                        <?php
+                        foreach ($navItems as $item) {
                         echo "<a class=\"btn btn-primary\" href=\"$item[slug]\" style=\"margin: 1px;\">$item[title]</a>";
                         }
                     ?>
-                    <?php
-            foreach ($navItemsBE as $item2) {
-                echo "<a class=\"btn btn-primary\" href=\"$item2[slug]\" style=\"margin: 1px;\">$item2[title]</a>";
-            }
-          	?>
         </div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- remove `navItemsNL`/`navItemsBE` usage and revert to `$navItems`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abb8e2f688324adc4c87b86577c38