### PR TITLE
Capture config from header

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -2,7 +2,8 @@
   $companyName = "Zoekertjes België";
   include $base . '/includes/nav_items.php';
   // Config is required for API lookups when rendering profile pages
-  include_once $base . '/config.php';
+  // Capture the returned configuration array for later use
+  $config = include $base . '/config.php';
 
   /**
    * Convert a string to a URL friendly slug.


### PR DESCRIPTION
## Summary
- load `config.php` into `$config` in the header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685abbafc04c83249937b6765dfc26cc