### PR TITLE
Fix canonical URLs and orphan pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,6 +7,11 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}.php -f
 RewriteRule ^(.+)$ $1.php [QSA]
 
+# Redirect outdated dating URLs to the correct datingtips pages
+RewriteRule ^dating-gegarandeerd-een-date/?$ https://zoekertjesbelgie.be/datingtips-gegarandeerd-een-date [R=301,L]
+RewriteRule ^dating-stout-contact/?$ https://zoekertjesbelgie.be/datingtips-stout-contact [R=301,L]
+RewriteRule ^dating-gratis-dating/?$ https://zoekertjesbelgie.be/datingtips-gratis-dating [R=301,L]
+
 RewriteRule ^dating-([a-z-]+)/?$ provincie.php?item=$1 [NC,L]
 RewriteRule ^datingtips-([a-z-]+)/?$ datingtips.php?item=$1 [NC,L]
 RewriteRule ^daten-met-[0-9a-zA-Z-]+$ profile.php [NC,L,QSA]

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -8,15 +8,15 @@
         <li><a href="https://datingcontact.co.uk/" target="_blank" class="m-0">Dating Contact UK</a> - </li>
         <li><a href="https://datingnebenan.de/" target="_blank" class="m-0">Dating Nebenan</a> - </li>
         <li><a href="https://e-notifyer.nl/" target="_blank" class="m-0">E-notifyer</a> - </li>
-      	<li><a href="partnerlinks.php">Meer partnerlinks...</a></li>
+        <li><a href="/partnerlinks">Meer partnerlinks...</a></li>
   </ul>
     <span class="sub-text">Copyright &copy; <?php echo date('Y'); ?> <?php echo $companyName; ?> | De gratis datingsite van België </span>
-    <span class="policy-links sub-text"><a href="/privacy.php">Privacybeleid</a> | <a href="/cookie-policy.php">Cookiebeleid</a></span>
+    <span class="policy-links sub-text"><a href="/privacy">Privacybeleid</a> | <a href="/cookie-policy">Cookiebeleid</a></span>
 </footer>
 <!-- Cookie Consent Banner -->
 <div id="cookie-banner" style="position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #ccc; font-family: Arial, sans-serif; padding: 20px; z-index: 10000; display: none;">
   <div style="max-width: 960px; margin: auto;">
-    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy.php" target="_blank">Cookie Policy</a>.</p>
+    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy" target="_blank">Cookie Policy</a>.</p>
     <form id="cookie-form">
       <label><input type="checkbox" disabled checked> Necessary (required)</label><br>
       <label><input type="checkbox" id="cookie-statistics"> Statistics (e.g. Google Analytics)</label><br>

--- a/includes/header.php
+++ b/includes/header.php
@@ -58,12 +58,13 @@
 <?php
     // Canonical URL logic
     $baseUrl = "https://zoekertjesbelgie.be";
-    $canonicalUrl = $baseUrl; // Default canonical URL
-    $title = "Zoekertjes België"; // Default title
-    if (isset($_GET['item'])) {
+    $canonicalUrl = isset($canonical) ? $canonical : $baseUrl; // Allow pages to override
+    $title = isset($pageTitle) ? $pageTitle : "Zoekertjes België"; // Default title
+
+    if (!isset($canonical) && isset($_GET['item'])) {
         $canonicalUrl = $baseUrl . "/dating-" . htmlspecialchars($_GET['item']);
         $title = "Dating " . htmlspecialchars($_GET['item']);
-    } else if (isset($_GET['id'])) {
+    } else if (!isset($canonical) && isset($_GET['id'])) {
         $id = preg_replace('/[^0-9]/', '', $_GET['id']);
         $apiResponse = @file_get_contents("https://20fhbe2020.be/profile/get0/8/" . $id);
         if ($apiResponse !== false) {
@@ -84,15 +85,21 @@
             $canonicalUrl = $baseUrl . "/profile?id=" . htmlspecialchars($_GET['id']);
             $title = "Daten met " . htmlspecialchars($_GET['id']);
         }
-    } else if (isset($_GET['tip'])) {
+    } else if (!isset($canonical) && isset($_GET['slug'])) {
+        $slug = strtolower($_GET['slug']);
+        $slug = preg_replace('/[^a-z0-9-]/', '', $slug);
+        $slug = trim($slug, '-');
+        $canonicalUrl = $baseUrl . '/daten-met-' . $slug;
+        $title = 'Daten met ' . str_replace('-', ' ', ucfirst($slug));
+    } else if (!isset($canonical) && isset($_GET['tip'])) {
         $canonicalUrl = $baseUrl . "/datingtips-" . htmlspecialchars($_GET['tip']);
         $title = "Datingtips " . htmlspecialchars($_GET['tip']);
     }
-    // When no query parameters are present, build canonical from script name
-    if (empty($_GET)) {
+    // When no query parameters are present and no override, build canonical from script name
+    if (!isset($canonical) && empty($_GET)) {
         $script = basename($_SERVER['SCRIPT_NAME']);
         if ($script !== 'index.php') {
-            $canonicalUrl = $baseUrl . '/' . $script;
+            $canonicalUrl = $baseUrl . '/' . str_replace('.php', '', $script);
         }
     }
     // Always append site name to the title when not already present


### PR DESCRIPTION
## Summary
- redirect outdated `/dating-*` URLs to existing dating tips
- honor per-page `$canonical` and `$pageTitle`
- generate canonical slugs for profile pages
- link to canonical privacy, cookie and partnerlinks URLs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d11f969bc8324a0390868f3548137